### PR TITLE
Deal with columns with weird names

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,15 +173,11 @@ func createTable(tableName *string, columnNames *[]string, db *sql.DB, verbose *
 	for i, col := range *columnNames {
 		var col_name string
 
-		reg := regexp.MustCompile(`-|\.|:`)
+		reg := regexp.MustCompile(`[^a-zA-Z0-9]`)
 
-		if reg.MatchString(col) {
-			col_name = reg.ReplaceAllString(col, "_")
-			if *verbose {
-				fmt.Fprintf(os.Stderr, "Column %x renamed to %s\n", col, col_name)
-			}
-		} else {
-			col_name = col
+		col_name = reg.ReplaceAllString(col, "_")
+		if *verbose && col_name != col {
+			fmt.Fprintf(os.Stderr, "Column %x renamed to %s\n", col, col_name)
 		}
 
 		buffer.WriteString(col_name + " TEXT")


### PR DESCRIPTION
Since the contents of a CSV field are essentially free-form text,
anything can be in that header line.  Instead of hand-picking a few
characters that will get transliterated to an underscore, transform
everything that doesn't belong to a very well defined set of characters.

We could so something more sophisticated here, like Unicode folding, but
I think for the purpose of a tool like textql this suffices.

Also, no need to match an then replace.  We can simply replace
unconditionally, and if nothing gets replaced, we get the same thing
back.
