### PR TITLE
Use first row as header row by default.

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	commands := flag.String("sql", "", "SQL Command(s) to run on the data")
 	source_text := flag.String("source", "stdin", "Source file to load, or defaults to stdin")
 	delimiter := flag.String("dlm", ",", "Delimiter between fields -dlm=tab for tab, -dlm=0x## to specify a character code in hex")
-	header := flag.Bool("header", false, "Treat file as having the first row as a header row")
+	header := flag.Bool("header", true, "Treat file as having the first row as a header row")
 	tableName := flag.String("table-name", "tbl", "Override the default table name (tbl)")
 	save_to := flag.String("save-to", "", "If set, sqlite3 db is left on disk at this path")
 	console := flag.Bool("console", false, "After all commands are run, open sqlite3 console with this data")


### PR DESCRIPTION
Somewhat a controversial change, especially considering that it's changing defaults, but, at least from my personal usage, I find that most CSV files have the first row as a header row.
