### PR TITLE
Using NUMERIC instead of TEXT

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func createTable(tableName *string, columnNames *[]string, db *sql.DB, verbose *
 			fmt.Fprintf(os.Stderr, "Column %x renamed to %s\n", col, col_name)
 		}
 
-		buffer.WriteString(col_name + " TEXT")
+		buffer.WriteString(col_name + " NUMERIC")
 
 		if i != len(*columnNames)-1 {
 			buffer.WriteString(", ")


### PR DESCRIPTION
NUMERIC is the highest in sqlite's type affinity rules.

https://www.sqlite.org/datatype3.html

Putting text in columns of type NUMERIC means they'll be actually treated as TEXT.

Fixes #42
