### PR TITLE
prevent slice bounds out of range

### DIFF
--- a/util/file_helpers.go
+++ b/util/file_helpers.go
@@ -74,7 +74,7 @@ func CleanPath(path string) string {
 		log.Fatalln(err)
 	}
 
-	if path[:2] == "~/" {
+	if len(path) > 1 && path[:2] == "~/" {
 		dir := usr.HomeDir + "/"
 		result = strings.Replace(path, "~/", dir, 1)
 	} else {


### PR DESCRIPTION
Prevent a slice bounds out of range runtime error in case like:

	$ textql f
	panic: runtime error: slice bounds out of range

	goroutine 1 [running]:
	github.com/dinedal/textql/util.CleanPath(0x7fff5fbff65f, 0x1, 0x0, 0x0)
	    /private/tmp/textql20151215-7563-khx4pl/textql-2.0.2/src/github.com/dinedal/textql/util/file_helpers.go:77 +0x3fc
	github.com/dinedal/textql/util.IsPathDir(0x7fff5fbff65f, 0x1, 0xc81fffc100)
	    /private/tmp/textql20151215-7563-khx4pl/textql-2.0.2/src/github.com/dinedal/textql/util/file_helpers.go:13 +0x51
	main.main()
	    /private/tmp/textql20151215-7563-khx4pl/textql-2.0.2/src/github.com/dinedal/textql/textql/main.go:141 +0x5b2

	goroutine 17 [syscall, locked to thread]:
	runtime.goexit()
	    /usr/local/Cellar/go/1.5.2/libexec/src/runtime/asm_amd64.s:1721 +0x1
	$