### PR TITLE
Fixed incorrect spelling of word Separator

### DIFF
--- a/inputs/csv.go
+++ b/inputs/csv.go
@@ -23,8 +23,8 @@ type CSVInput struct {
 type CSVInputOptions struct {
 	// HasHeader when true, will treat the first row as a header row.
 	HasHeader bool
-	// Seperator is the rune that fields are delimited by.
-	Seperator rune
+	// Separator is the rune that fields are delimited by.
+	Separator rune
 	// ReadFrom is where the data will be read from.
 	ReadFrom io.Reader
 }
@@ -41,7 +41,7 @@ func NewCSVInput(opts *CSVInputOptions) (*CSVInput, error) {
 	csvInput.firstRow = nil
 
 	csvInput.reader.FieldsPerRecord = -1
-	csvInput.reader.Comma = csvInput.options.Seperator
+	csvInput.reader.Comma = csvInput.options.Separator
 	csvInput.reader.LazyQuotes = true
 
 	headerErr := csvInput.readHeader()

--- a/inputs/csv_test.go
+++ b/inputs/csv_test.go
@@ -37,7 +37,7 @@ func TestCSVInputFakesHeader(t *testing.T) {
 
 	opts := &CSVInputOptions{
 		HasHeader: false,
-		Seperator: ',',
+		Separator: ',',
 		ReadFrom:  fp,
 	}
 
@@ -56,7 +56,7 @@ func TestCSVInputReadsHeader(t *testing.T) {
 
 	opts := &CSVInputOptions{
 		HasHeader: true,
-		Seperator: ',',
+		Separator: ',',
 		ReadFrom:  fp,
 	}
 
@@ -75,7 +75,7 @@ func TestCSVInputReadsSimple(t *testing.T) {
 
 	opts := &CSVInputOptions{
 		HasHeader: true,
-		Seperator: ',',
+		Separator: ',',
 		ReadFrom:  fp,
 	}
 
@@ -99,7 +99,7 @@ func TestCSVInputReadsBad(t *testing.T) {
 
 	opts := &CSVInputOptions{
 		HasHeader: true,
-		Seperator: ',',
+		Separator: ',',
 		ReadFrom:  fp,
 	}
 
@@ -129,7 +129,7 @@ func TestCSVInputHasAName(t *testing.T) {
 
 	opts := &CSVInputOptions{
 		HasHeader: true,
-		Seperator: ',',
+		Separator: ',',
 		ReadFrom:  fp,
 	}
 

--- a/outputs/csv.go
+++ b/outputs/csv.go
@@ -22,8 +22,8 @@ type CSVOutput struct {
 type CSVOutputOptions struct {
 	// WriteHeader determines if a header row based on the column names should be written.
 	WriteHeader bool
-	// Seperator is the rune used to delimit fields.
-	Seperator rune
+	// Separator is the rune used to delimit fields.
+	Separator rune
 	// WriteTo is where the formatted data will be written to.
 	WriteTo io.Writer
 }
@@ -35,7 +35,7 @@ func NewCSVOutput(opts *CSVOutputOptions) *CSVOutput {
 		writer:  csv.NewWriter(opts.WriteTo),
 	}
 
-	csvOutput.writer.Comma = csvOutput.options.Seperator
+	csvOutput.writer.Comma = csvOutput.options.Separator
 
 	return csvOutput
 }

--- a/storage/sqlite_test.go
+++ b/storage/sqlite_test.go
@@ -27,7 +27,7 @@ func NewTestCSVInput() (input inputs.Input, fp *os.File) {
 
 	opts := &inputs.CSVInputOptions{
 		HasHeader: true,
-		Seperator: ',',
+		Separator: ',',
 		ReadFrom:  fp,
 	}
 
@@ -170,7 +170,7 @@ func LoadTestDataAndExecuteQuery(t *testing.T, testData string, sqlString string
 
 	opts := &inputs.CSVInputOptions{
 		HasHeader: true,
-		Seperator: ',',
+		Separator: ',',
 		ReadFrom:  fp,
 	}
 

--- a/textql/main.go
+++ b/textql/main.go
@@ -160,7 +160,7 @@ func main() {
 
 		inputOpts := &inputs.CSVInputOptions{
 			HasHeader: cmdLineOpts.GetHeader(),
-			Seperator: util.DetermineSeparator(cmdLineOpts.GetDelimiter()),
+			Separator: util.DetermineSeparator(cmdLineOpts.GetDelimiter()),
 			ReadFrom:  fp,
 		}
 
@@ -186,7 +186,7 @@ func main() {
 		} else {
 			displayOpts := &outputs.CSVOutputOptions{
 				WriteHeader: cmdLineOpts.GetOutputHeader(),
-				Seperator:   util.DetermineSeparator(cmdLineOpts.GetOutputDelimiter()),
+				Separator:   util.DetermineSeparator(cmdLineOpts.GetOutputDelimiter()),
 				WriteTo:     util.OpenFileOrStdDev(cmdLineOpts.GetOutputFile(), true),
 			}
 


### PR DESCRIPTION
I am not sure if you are interested in a typo, but I figured it might be worth fixing and asking about it. No functional changes here, just one letter switched from `e` to `a`.