### PR TITLE
Changes golang package for getting base of filenames to "path/filepath"

### DIFF
--- a/inputs/csv.go
+++ b/inputs/csv.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strconv"
 )
 
@@ -51,7 +51,7 @@ func NewCSVInput(opts *CSVInputOptions) (*CSVInput, error) {
 	}
 
 	if asFile, ok := csvInput.options.ReadFrom.(*os.File); ok {
-		csvInput.name = path.Base(asFile.Name())
+		csvInput.name = filepath.Base(asFile.Name())
 	} else {
 		csvInput.name = "pipe"
 	}


### PR DESCRIPTION
The "path.Base()" is replaced with "filepath.Base()" as the first is
supposed to be used with non-filesystem slash-based paths, e.g. URL. The
latter is specifically implemented to cope with filesystem peculiarities.

Fixes #80
Related to #79