### PR TITLE
Don't print blank results for queries that create tables

### DIFF
--- a/outputs/csv.go
+++ b/outputs/csv.go
@@ -48,7 +48,7 @@ func (csvOutput *CSVOutput) Show(rows *sql.Rows) {
 		log.Fatalln(colsErr)
 	}
 
-	if csvOutput.options.WriteHeader {
+	if csvOutput.options.WriteHeader && len(cols) > 0 {
 		if err := csvOutput.writer.Write(cols); err != nil {
 			log.Fatalln(err)
 		}

--- a/outputs/pretty_csv.go
+++ b/outputs/pretty_csv.go
@@ -69,6 +69,8 @@ func (prettyCsvOutput *PrettyCSVOutput) Show(rows *sql.Rows) {
 		prettyCsvOutput.writer.Append(result)
 	}
 
-	prettyCsvOutput.writer.Render()
+	if len(cols) > 0 {
+		prettyCsvOutput.writer.Render()
+	}
 	rows.Close()
 }


### PR DESCRIPTION
This resolves #85 

```
$ textql -output-header -sql "create temp table one(word text); create temp table two(id integer); select *;" <(printf "a,1\nb,2\nc,3")
c0,c1
a,1
b,2
c,3
```
```
$ textql -pretty -sql "create temp table one(word text); create temp table two(id integer); select *;" <(printf "a,1\nb,2\nc,3")
+---+---+
| a | 1 |
| b | 2 |
| c | 3 |
+---+---+
```