### PR TITLE
add sqlite3 to docker image for option "-console"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.10
 
+# install sqlite3 for option "-console"
+RUN apt-get update && apt-get install -y sqlite3
+
 WORKDIR /go/src/app
 COPY . .
 


### PR DESCRIPTION
fix #93

# Problem

```console
$ sudo docker run --rm -it -v $(pwd):/tmp textql -console test.csv                                    
2018/05/10 09:32:30 Console requested but unable to locate `sqlite3` program on $PATH
```

# Root cause

sqlite3 is not included in Docker image

# Solution

Install sqlite3 command in Dockerfile

# Test

```console
vagrant@k8smaster:~/dev/textql$ cat test.csv
first_name,last_name,ssn
John,Barry,123456
Kathy,Smith,687987
Bob,McCornick,3979870

# test "-sql"
vagrant@k8smaster:~/dev/textql$ sudo docker run --rm -it -v $(pwd):/tmp textql -header -sql 'SELECT * FROM test' test.csv
John,Barry,123456
Kathy,Smith,687987
Bob,McCornick,3979870

# test "-console"
vagrant@k8smaster:~/dev/textql$ sudo docker run --rm -it -v $(pwd):/tmp textql -header -console test.csv
SQLite version 3.16.2 2017-01-06 16:32:41
Enter ".help" for usage hints.
sqlite> SELECT * FROM test;
John|Barry|123456
Kathy|Smith|687987
Bob|McCornick|3979870
sqlite> SELECT * FROM test WHERE ssn>200000;
Kathy|Smith|687987
Bob|McCornick|3979870
sqlite>
vagrant@k8smaster:~/dev/textql$  