### PR TITLE
reduce docker image to 19MB

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,16 @@
+FROM golang:1.10-alpine3.7 AS build
+
+# "build-base" for gcc
+RUN apk update && apk add git && apk add build-base
+WORKDIR /go/src/app
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+FROM alpine:3.7
+RUN apk add --update-cache sqlite
+COPY --from=build /go/bin/textql /usr/bin
+WORKDIR /tmp
+ENTRYPOINT ["textql"]
+


### PR DESCRIPTION
fix #95 

Reduce docker image from 300MB to 19MB

Dockerfile.alpine requires Docker 17.05 or higher for it uses [multi-stage build](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#use-multi-stage-builds). Refer to [docker installation](https://docs.docker.com/install/linux/docker-ce/ubuntu/) for how to install it.

Details design document in <https://github.com/yuanyangwu/yuanyangwu.github.io/blob/master/_posts/2018-05-22-minimize-textql-docker-image.md>

Test

```console
# build image
vagrant@ubuntu-xenial:~/textql$ sudo docker build -f Dockerfile.alpine -t textql:alpine .

# new image size is 19MB
vagrant@ubuntu-xenial:~/textql$ sudo docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
textql              alpine              f800704c4c9d        3 minutes ago       18.8MB

# csv file
vagrant@ubuntu-xenial:~/textql$ cat test.csv
first_name,last_name,ssn
John,Barry,123456
Kathy,Smith,687987
Bob,McCornick,3979870

# test "-sql"
vagrant@ubuntu-xenial:~/textql$ sudo docker run --rm -it -v $(pwd):/tmp textql:alpine -header -sql 'SELECT * FROM test' test.csv
John,Barry,123456
Kathy,Smith,687987
Bob,McCornick,3979870

# test "-console"
vagrant@ubuntu-xenial:~/textql$ sudo docker run --rm -it -v $(pwd):/tmp textql:alpine -header -console test.csv
SQLite version 3.21.0 2017-10-24 18:55:49
Enter ".help" for usage hints.
sqlite> SELECT * FROM test;
John|Barry|123456
Kathy|Smith|687987
Bob|McCornick|3979870
sqlite> SELECT * FROM test WHERE ssn>200000;
Kathy|Smith|687987
Bob|McCornick|3979870
sqlite>
```
