### PR TITLE
Add support for tagged filename (label:path) to specify tablename

### DIFF
--- a/textql/main.go
+++ b/textql/main.go
@@ -143,19 +143,27 @@ func main() {
 		inputSources = append(inputSources, "stdin")
 	}
 
-	for _, sourceFile := range cmdLineOpts.GetSourceFiles() {
+	for _, taggedName := range cmdLineOpts.GetSourceFiles() {
+		// support <tablename>:<filename> syntax
+		var names = strings.SplitN(taggedName, ":", 2)
+		var sourceFile = names[len(names) - 1]
+
 		if util.IsPathDir(sourceFile) {
 			for _, file := range util.AllFilesInDirectory(sourceFile) {
 				inputSources = append(inputSources, file)
 			}
 		} else {
-			inputSources = append(inputSources, sourceFile)
+			inputSources = append(inputSources, taggedName)
 		}
 	}
 
 	storage := storage.NewSQLite3StorageWithDefaults()
 
-	for _, file := range inputSources {
+	for _, taggedName := range inputSources {
+		// support <tablename>:<filename> syntax
+		var names = strings.SplitN(taggedName, ":", 2)
+		var file = names[len(names) - 1]
+
 		fp := util.OpenFileOrStdDev(file, false)
 
 		inputOpts := &inputs.CSVInputOptions{
@@ -170,6 +178,9 @@ func main() {
 			log.Printf("Unable to load %v\n", file)
 		}
 
+		if len(names) > 1 {
+			input.SetName(names[0])
+		}
 		storage.LoadInput(input)
 	}
 


### PR DESCRIPTION
Hi,
I added support for "tagged" filename, that allows you to specify table name explicitly.

This is useful when you are on bash or zsh that allows you to pass command output as anonymous file (actually, a pipe).
```
$ textql -sql 'select * from foo' foo:<(tail -3 /etc/group) bar:<(head -3 /etc/group)
motion:x:122:
lpadmin:x:123:
ntop:x:124:
```

Without this patch, you need to specify each table using file descriptor number which shell has allocated. It happens to be 63, 62, etc on my environment, but having a name for a table is much easier to use.

```
$ textql -sql 'select * from "63"' <(tail -3 /etc/group)
motion:x:122:
lpadmin:x:123:
ntop:x:124:
```

Best,
