### PR TITLE
Added fuzzer for sqlparser

### DIFF
--- a/sqlparser/fuzz.go
+++ b/sqlparser/fuzz.go
@@ -1,0 +1,9 @@
+package sqlparser
+
+func Fuzz(data []byte) int {
+	_, err := Parse(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer to the sql parser.
It can be run both locally and on oss-fuzz's infrastructure, and I will be happy to setup an integration application to oss-fuzz to run the fuzzer continuously. oss-fuzz is a free service that is offered with an implied expectation that bugs are fixed by the maintainers.
If a bug is found through oss-fuzz, a link to a detailed bug report is sent to the contact email addresses of textql. All I need to apply for integration are the email addresses for this list. The list is public and can be changed at any time.