### PR TITLE
Remove "import will not accept stdin" from readme, it does

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,6 @@ Bug fixes:
 
 ## Key differences between textql and sqlite importing
 
-- sqlite import will not accept stdin, breaking unix pipes. textql will happily do so.
 - textql supports quote-escaped delimiters, sqlite does not.
 - textql leverages the sqlite in-memory database feature as much as possible and only touches disk if asked.
 


### PR DESCRIPTION
sqlite will happily accept stdin if you tell it `.import /dev/stdin {tablename}`. For example this works just fine:

`gzip -dc icons.csv.gz | sqlite3 ':memory:' -csv '.import /dev/stdin data' '.output /dev/stdout' '.headers on' "SELECT name, keywords from data where name = 'chart-area'" | gzip - > icons2.csv.gz`