### PR TITLE
Fix TestCSVInputHasAName with Go 1.17

### DIFF
--- a/inputs/csv_test.go
+++ b/inputs/csv_test.go
@@ -134,7 +134,7 @@ func TestCSVInputHasAName(t *testing.T) {
 	}
 
 	input, _ := NewCSVInput(opts)
-	expected := fp.Name()
+	expected := strings.ReplaceAll(fp.Name(), "./", "")
 
 	if !reflect.DeepEqual(input.Name(), expected) {
 		t.Errorf("Name() = %v, want %v", input.Name(), expected)


### PR DESCRIPTION
Closes https://github.com/dinedal/textql/issues/135