### PR TITLE
Add support for reading SQL from a file

### DIFF
--- a/textql/main.go
+++ b/textql/main.go
@@ -59,7 +59,7 @@ func (clo *commandLineOptions) GetStatements() (string, *error) {
 		err := fmt.Errorf("No SQL statements provided")
 		return "", &err
 	}
-	if clo.Statements != nil {
+	if clo.Statements != nil && *clo.Statements != "" {
 		return *clo.Statements, nil
 	}
 	filepath := *clo.StatementsFile


### PR DESCRIPTION
Add support for reading SQL source from a file.
This PR make textql possible to read query from single file like this:

```shell
textql -sqlfile <path to sql file> ...
```
